### PR TITLE
Disable sed conf Update and trust anchor update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ These options can be set via the environment variable -e flag:
 - **ENABLE_REMOTE_CONTROL**: Enable or disable the unbound-control command. (Default: "no", Values: "yes, no")
 - **USE_LOGFILE**: Use log file instead of stdout (Default: "no", Values: "yes, no")
 - **USE_CHROOT**: Use chroot while running unbound. (Default: "yes", Possible values: "yes,no")
+- **UPDATE_TRUST_ANCHOR**: Enable oder Disable update of the root trust anchor for DNSSEC validation at startup (Default: "yes", Values: "yes, no")
+- **DISABLE_CONF_VARS**: Enable oder Disable update of unbound.conf through environment variable (Default: "no", Values: "yes, no")
 
 # More config control
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ If you want to override the nameserver in the unbound container, you can use:
 # Configuration
 These options can be set via the environment variable -e flag:
 
-- **INTERFACE**: Sets the interface to listen to. (Default: 0.0.0.0, Values: <IP addr>)
-- **PORT**: Port number that unbound will listen. This has to be the same of the docker run. (Default: 53, Values: <1-65535>)
+- **INTERFACE**: Sets the interface to listen to. (Default: 0.0.0.0, Values: \<IP addr>)
+- **PORT**: Port number that unbound will listen. This has to be the same of the docker run. (Default: 53, Values: \<<1-65535>)
 - **DO_IPV6**: Enable or disable ipv6. (Default: "yes", Values: "yes, no")
 - **DO_IPV4**: Enable or disable ipv4. (Default: "yes", Values: "yes, no")
 - **DO_UDP**: Enable or disable udp. (Default: "yes", Values: "yes, no")
 - **DO_TCP**: Enable or disable tcp. (Default: "yes", Values: "yes, no")
-- **VERBOSITY**: Verbosity number, 0 is least verbose. (Default: "0", Values: "<integer>")
+- **VERBOSITY**: Verbosity number, 0 is least verbose. (Default: "0", Values: "\<<integer>")
 - **SO_REUSEPORT**: Use SO_REUSEPORT to distribute queries over threads. (Default: "no", Values: "yes, no")
 - **HIDE_IDENTITY**: Enable to not answer id.server and hostname.bind queries. (Default: "no", Values: "yes, no")
 - **HIDE_VERSION**: Enable to not answer version.server and version.bind queries. (Default: "no", Values: "yes, no")

--- a/resources/unbound.sh
+++ b/resources/unbound.sh
@@ -20,6 +20,7 @@ USE_LOGFILE=${ENABLE_LOGFILE:-no}
 USE_CHROOT=${ENABLE_LOGFILE:-yes}
 ENABLE_REMOTE_CONTROL=${ENABLE_REMOTE_CONTROL:-no}
 DISABLE_CONF_VARS=${DISABLE_CONF_VARS:-no}
+UPDATE_TRUST_ANCHOR=${UPDATE_TRUST_ANCHOR:-yes}
 
 if [ "x${DISABLE_CONF_VARS}" = "xno" ]; then
   sed 's/{{PORT}}/'"${PORT}"'/' -i /opt/unbound/etc/unbound/unbound.conf
@@ -63,9 +64,11 @@ else
   chown unbound.unbound /opt/unbound/etc/unbound
 fi
 
-
-/opt/unbound/sbin/unbound-anchor -a /opt/unbound/etc/unbound/root.key
-chown unbound.unbound /opt/unbound/etc/unbound/root.key
+if [ "x${UPDATE_TRUST_ANCHOR}" = "xyes" ]; then
+  echo "Update root trust anchor for DNSSEC validation."
+  /opt/unbound/sbin/unbound-anchor -a /opt/unbound/etc/unbound/root.key
+  chown unbound.unbound /opt/unbound/etc/unbound/root.key
+fi
 
 cat /opt/unbound/etc/unbound/unbound.conf
 echo "-----------------------------------------------"

--- a/resources/unbound.sh
+++ b/resources/unbound.sh
@@ -19,35 +19,38 @@ USE_CAPS_FOR_ID=${USE_CAPS_FOR_ID:-yes}
 USE_LOGFILE=${ENABLE_LOGFILE:-no}
 USE_CHROOT=${ENABLE_LOGFILE:-yes}
 ENABLE_REMOTE_CONTROL=${ENABLE_REMOTE_CONTROL:-no}
+DISABLE_CONF_VARS=${DISABLE_CONF_VARS:-no}
 
-sed 's/{{PORT}}/'"${PORT}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{DO_IPV6}}/'"${DO_IPV6}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{DO_IPV4}}/'"${DO_IPV4}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{DO_UDP}}/'"${DO_UDP}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{DO_TCP}}/'"${DO_TCP}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{INTERFACE}}/'"${INTERFACE}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{SO_REUSEPORT}}/'"${SO_REUSEPORT}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{HIDE_IDENTITY}}/'"${HIDE_IDENTITY}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{HIDE_VERSION}}/'"${HIDE_VERSION}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{VERBOSITY}}/'"${VERBOSITY}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{NUM_THREADS}}/'"${NUM_THREADS}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{QNAME_MINIMISATION}}/'"${QNAME_MINIMISATION}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{RRSET_ROUNDROBIN}}/'"${RRSET_ROUNDROBIN}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{USE_CAPS_FOR_ID}}/'"${USE_CAPS_FOR_ID}"'/' -i /opt/unbound/etc/unbound/unbound.conf
-sed 's/{{ENABLE_REMOTE_CONTROL}}/'"${ENABLE_REMOTE_CONTROL}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+if [ "x${DISABLE_CONF_VARS}" = "xno" ]; then
+  sed 's/{{PORT}}/'"${PORT}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{DO_IPV6}}/'"${DO_IPV6}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{DO_IPV4}}/'"${DO_IPV4}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{DO_UDP}}/'"${DO_UDP}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{DO_TCP}}/'"${DO_TCP}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{INTERFACE}}/'"${INTERFACE}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{SO_REUSEPORT}}/'"${SO_REUSEPORT}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{HIDE_IDENTITY}}/'"${HIDE_IDENTITY}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{HIDE_VERSION}}/'"${HIDE_VERSION}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{VERBOSITY}}/'"${VERBOSITY}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{NUM_THREADS}}/'"${NUM_THREADS}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{QNAME_MINIMISATION}}/'"${QNAME_MINIMISATION}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{RRSET_ROUNDROBIN}}/'"${RRSET_ROUNDROBIN}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{USE_CAPS_FOR_ID}}/'"${USE_CAPS_FOR_ID}"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  sed 's/{{ENABLE_REMOTE_CONTROL}}/'"${ENABLE_REMOTE_CONTROL}"'/' -i /opt/unbound/etc/unbound/unbound.conf
 
-if [ "x${ENABLE_REMOTE_CONTROL}" = "xyes" ]; then
-  if [ ! -f /opt/unbound/etc/unbound/unbound_control.key ]; then
-    /opt/unbound/sbin/unbound-control-setup 1>/dev/null 2>&1 || true
+  if [ "x${ENABLE_REMOTE_CONTROL}" = "xyes" ]; then
+    if [ ! -f /opt/unbound/etc/unbound/unbound_control.key ]; then
+      /opt/unbound/sbin/unbound-control-setup 1>/dev/null 2>&1 || true
+    fi
   fi
-fi
 
-if [ "x${USE_LOGFILE}" = "xyes" ]; then
-  mkdir -p /opt/unbound/etc/unbound/log && \
-     chown unbound.unbound /opt/unbound/etc/unbound/log
-  sed 's/{{LOGFILE}}/'"log/unbound.log"'/' -i /opt/unbound/etc/unbound/unbound.conf
-else
-  sed 's/{{LOGFILE}}/'""'/' -i /opt/unbound/etc/unbound/unbound.conf
+  if [ "x${USE_LOGFILE}" = "xyes" ]; then
+    mkdir -p /opt/unbound/etc/unbound/log && \
+       chown unbound.unbound /opt/unbound/etc/unbound/log
+    sed 's/{{LOGFILE}}/'"log/unbound.log"'/' -i /opt/unbound/etc/unbound/unbound.conf
+  else
+    sed 's/{{LOGFILE}}/'""'/' -i /opt/unbound/etc/unbound/unbound.conf
+  fi
 fi
 
 if [ "x${USE_CHROOT}" = "xno" ]; then


### PR DESCRIPTION
Hi,
great work!

I have added two more options to make the image usable in my environment and hope they can be adapted to make it more universal. 

**Option UPDATE_TRUST_ANCHOR:**
Disable update of trust anchor update for locale only dns server

**Option DISABLE_CONF_VARS:**
Allow to modify of all settings through mounted unbound.conf

Regards
Alex 